### PR TITLE
use non-copying ByteBuffer transfer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ project/plugins/project/
 
 # Scala-IDE specific
 .scala_dependencies
+/.target/
+.cache-main
+.classpath
+.project
+.settings/

--- a/src/main/java/scodec/interop/akka/PrivacyHelper.java
+++ b/src/main/java/scodec/interop/akka/PrivacyHelper.java
@@ -1,0 +1,13 @@
+package scodec.interop.akka;
+
+import java.nio.ByteBuffer;
+
+import akka.util.ByteString.ByteString1C;
+
+interface PrivacyHelper {
+
+	static ByteString1C createByteString1C(ByteBuffer buffer) {
+		return new ByteString1C(buffer.array());
+	}
+	
+}

--- a/src/main/scala/scodec/interop/akka/package.scala
+++ b/src/main/scala/scodec/interop/akka/package.scala
@@ -7,10 +7,10 @@ import _root_.akka.util.ByteString
 package object akka {
 
   implicit class EnrichedByteString(val value: ByteString) extends AnyVal {
-    def toByteVector: ByteVector = ByteVector(value.asByteBuffer)
+    def toByteVector: ByteVector = ByteVector.view(value.asByteBuffer)
   }
 
   implicit class EnrichedByteVector(val value: ByteVector) extends AnyVal {
-    def toByteString: ByteString = ByteString(value.toByteBuffer)
+    def toByteString: ByteString = PrivacyHelper.createByteString1C(value.toByteBuffer)
   }
 }


### PR DESCRIPTION
The unsafe constructor for compact ByteStrings is `private[akka]`, so either we put code in the `akka` package (which is ugly) or use Java (which is ugly). This is a proposal for the latter.

This is a partial fix for #1 which only treats the case of compact ByteStrings and ByteVectors, what remains to be done is to translate the scattered variants.
